### PR TITLE
add clippy and rustfmt and align the codebase

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,26 +23,20 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          override: true
           default: true
-          components: rustfmt
+          components: clippy, rustfmt
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
         with:
           version: "v0.4.0"
-      - name: Run cargo check
-        run: cargo check
-# Disabled Due to issue with rustfmt our team has.
-#      - name: Run cargo fmt check
-#        run: |
-#          set;
-#          ls -la ~/.config/;
-#          cargo --version;
-#          cargo fmt --version;
-#          if ! cargo fmt --check --verbose ; then
-#            echo "Formatting errors detected, please run 'cargo fmt' to fix it";
-#            exit 1
-#          fi
+      - name: Run cargo clippy
+        run: cargo clippy --all-features --all-targets -- -D warnings
+      - name: Run cargo fmt check
+        run: |
+          if ! cargo fmt --check --verbose ; then
+            echo "Formatting errors detected, please run 'cargo fmt' to fix it";
+            exit 1
+          fi
 
   # Check that every combination of features is working properly.
   hack:
@@ -57,9 +51,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          override: true
           default: true
-          components: rustfmt
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
       - name: cargo install cargo-hack
@@ -67,6 +59,7 @@ jobs:
       # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
       - name: cargo hack
         run: cargo hack --feature-powerset check
+
   test:
     runs-on: ubuntu-latest
     env:
@@ -78,15 +71,14 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          override: true
           default: true
-          components: rustfmt
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
         with:
           version: "v0.4.0"
       - name: Run cargo test
-        run: cargo test
+        run: cargo test --all-features
+
   coverage:
     runs-on: ubuntu-latest
     env:
@@ -101,8 +93,7 @@ jobs:
         with:
           toolchain: stable
           default: true
-          override: true
-          components: rustfmt, llvm-tools-preview
+          components: llvm-tools-preview
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
       - name: cargo install cargo-llvm-cov
@@ -113,6 +104,7 @@ jobs:
       - name: cargo llvm-cov
         run: cargo llvm-cov --locked --all-features --lcov --output-path lcov.info
       - name: Upload to codecov.io
+        if: ${{ github.repository == 'Sovereign-Labs/nmt-rs' }}
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true

--- a/src/nmt_proof.rs
+++ b/src/nmt_proof.rs
@@ -16,10 +16,7 @@ use crate::{
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum NamespaceProof<M: MerkleHash> {
     AbsenceProof {
         proof: Proof<M>,
@@ -68,12 +65,8 @@ impl<M: NamespaceMerkleHasher<Output = NamespacedHash>> NamespaceProof<M> {
                 .iter()
                 .map(|data| NamespacedHash::hash_leaf(data.as_ref(), leaf_namespace))
                 .collect();
-            tree.inner.check_range_proof(
-                root,
-                &mut &leaf_hashes[..],
-                &mut siblings,
-                start_idx as usize,
-            )?;
+            tree.inner
+                .check_range_proof(root, &leaf_hashes, &mut siblings, start_idx as usize)?;
             Ok(())
         } else {
             Err(RangeProofError::MalformedProof)

--- a/src/simple_merkle/proof.rs
+++ b/src/simple_merkle/proof.rs
@@ -14,10 +14,7 @@ use super::{
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Proof<M: MerkleHash> {
     pub siblings: Vec<M::Output>,
     pub start_idx: u32,
@@ -37,7 +34,7 @@ where
 
         tree.check_range_proof(
             root,
-            &mut &leaf_hashes[..],
+            leaf_hashes,
             &mut self.siblings,
             self.start_idx as usize,
         )?;
@@ -45,7 +42,7 @@ where
     }
 
     pub fn siblings(&self) -> &Vec<M::Output> {
-        &&self.siblings
+        &self.siblings
     }
 
     pub fn start_idx(&self) -> u32 {


### PR DESCRIPTION
Hi, I previously said that I'll remove the CI changes from the namespace id generic over length PR, but I think those changes makes it easier to contribute at all, so maybe you'll reconsider those.
It re-enables `cargo fmt`, changes `cargo check` to `cargo clippy` and only tries to push coverage stats when CI is ran on your original repository.
As an example I apply cargo fmt and clippy on save, so if it reformats and warns me about some code places all the time when reading through, it feels kind of disturbing. Not sure what settings did your team try with fmt, but aligning to common standards makes it easier for other ppl to pick up.