### PR TITLE
feat: require M::Output Copy and verify proofs by ref

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@ where
             proof,
             ignore_max_ns: self.ignore_max_ns,
         };
-        proof.convert_to_absence_proof(self.inner.leaves()[idx].hash);
+        proof.convert_to_absence_proof(self.inner.leaves()[idx].hash.clone());
         proof
     }
 
@@ -273,7 +273,7 @@ where
                 if !root.contains(namespace) {
                     return Ok(());
                 }
-                let leaf = leaf.ok_or(RangeProofError::MalformedProof)?;
+                let leaf = leaf.clone().ok_or(RangeProofError::MalformedProof)?;
                 // Check that they haven't provided an absence proof for a non-empty namespace
                 if !raw_leaves.is_empty() {
                     return Err(RangeProofError::MalformedProof);
@@ -459,7 +459,8 @@ mod tests {
         for i in 1..=n {
             for j in 0..=i {
                 let proof = tree.build_range_proof(j..i);
-                let leaf_hashes: Vec<_> = tree.leaves()[j..i].iter().map(|l| l.hash).collect();
+                let leaf_hashes: Vec<_> =
+                    tree.leaves()[j..i].iter().map(|l| l.hash.clone()).collect();
                 let res = tree.check_range_proof(&root, &leaf_hashes, proof.siblings(), j);
                 if i != j {
                     dbg!(i, j, &res);
@@ -494,7 +495,7 @@ mod tests {
             let _ = tree.push_leaf(x.to_be_bytes().as_ref(), namespace);
         }
         let root = tree.root();
-        let leaf_hashes: Vec<_> = tree.leaves().iter().map(|x| x.hash).collect();
+        let leaf_hashes: Vec<_> = tree.leaves().iter().map(|x| x.hash.clone()).collect();
 
         // For each potential range of size four, build and check a range proof
         for i in 0..=28 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-// #![feature(slice_take)]
-
 use std::{collections::HashMap, ops::Range};
 
 pub use nmt_proof::NamespaceProof;
@@ -28,7 +26,7 @@ pub type CelestiaNmt = NamespaceMerkleTree<
 /// Checks if a proof contains any partial namespaces
 fn check_proof_completeness<const NS_ID_SIZE: usize>(
     leaves: &[NamespacedHash<NS_ID_SIZE>],
-    proof: &Vec<NamespacedHash<NS_ID_SIZE>>,
+    proof: &[NamespacedHash<NS_ID_SIZE>],
     num_left_siblings: usize,
 ) -> RangeProofType {
     // Check if the proof is complete
@@ -117,7 +115,7 @@ where
         &self,
         root: &NamespacedHash<NS_ID_SIZE>,
         leaves: &[NamespacedHash<NS_ID_SIZE>],
-        proof: &mut Vec<NamespacedHash<NS_ID_SIZE>>,
+        proof: &[NamespacedHash<NS_ID_SIZE>],
         leaves_start_idx: usize,
     ) -> Result<RangeProofType, RangeProofError> {
         // As an optimization, the internal call doesn't recurse into subtrees of size smaller than 2
@@ -255,7 +253,7 @@ where
             proof,
             ignore_max_ns: self.ignore_max_ns,
         };
-        proof.convert_to_absence_proof(self.inner.leaves()[idx].hash.clone());
+        proof.convert_to_absence_proof(self.inner.leaves()[idx].hash);
         proof
     }
 
@@ -264,22 +262,14 @@ where
         root: &NamespacedHash<NS_ID_SIZE>,
         raw_leaves: &[impl AsRef<[u8]>],
         namespace: NamespaceId<NS_ID_SIZE>,
-        proof: NamespaceProof<M, NS_ID_SIZE>,
+        proof: &NamespaceProof<M, NS_ID_SIZE>,
     ) -> Result<(), RangeProofError> {
         if root.is_empty_root() && raw_leaves.is_empty() {
             return Ok(());
         }
 
         match proof {
-            NamespaceProof::AbsenceProof {
-                proof:
-                    Proof {
-                        mut siblings,
-                        start_idx,
-                    },
-                ignore_max_ns: _,
-                leaf,
-            } => {
+            NamespaceProof::AbsenceProof { leaf, .. } => {
                 if !root.contains(namespace) {
                     return Ok(());
                 }
@@ -292,9 +282,10 @@ where
                 if namespace >= leaf.min_namespace() {
                     return Err(RangeProofError::MalformedProof);
                 }
-                let num_left_siblings = compute_num_left_siblings(start_idx as usize);
+                let num_left_siblings = compute_num_left_siblings(proof.start_idx() as usize);
 
                 // Check that the namespace actually follows the closest sibling
+                let siblings = proof.siblings();
                 if num_left_siblings > 0 {
                     let rightmost_left_sibling = &siblings[num_left_siblings - 1];
                     if rightmost_left_sibling.max_namespace() >= namespace {
@@ -302,17 +293,14 @@ where
                     }
                 }
                 // Then, check that the root is real
-                self.inner
-                    .check_range_proof(root, &[leaf], &mut siblings, start_idx as usize)?;
+                self.inner.check_range_proof(
+                    root,
+                    &[leaf],
+                    proof.siblings(),
+                    proof.start_idx() as usize,
+                )?;
             }
-            NamespaceProof::PresenceProof {
-                proof:
-                    Proof {
-                        mut siblings,
-                        start_idx,
-                    },
-                ignore_max_ns: _,
-            } => {
+            NamespaceProof::PresenceProof { .. } => {
                 if !root.contains(namespace) {
                     return Err(RangeProofError::TreeDoesNotContainLeaf);
                 }
@@ -320,9 +308,13 @@ where
                     .iter()
                     .map(|data| NamespacedHash::hash_leaf(data.as_ref(), namespace))
                     .collect();
-                if let RangeProofType::Partial =
-                    self.check_range_proof(root, &leaf_hashes, &mut siblings, start_idx as usize)?
-                {
+                let proof_type = self.check_range_proof(
+                    root,
+                    &leaf_hashes,
+                    proof.siblings(),
+                    proof.start_idx() as usize,
+                )?;
+                if proof_type == RangeProofType::Partial {
                     return Err(RangeProofError::MissingLeaf);
                 }
             }
@@ -409,7 +401,6 @@ mod tests {
         let no_leaves: &[&[u8]] = &[];
 
         proof
-            .clone()
             .verify_complete_namespace(&tree.root(), no_leaves, namespace)
             .unwrap();
 
@@ -468,10 +459,8 @@ mod tests {
         for i in 1..=n {
             for j in 0..=i {
                 let proof = tree.build_range_proof(j..i);
-                let leaf_hashes: Vec<_> =
-                    tree.leaves()[j..i].iter().map(|l| l.hash.clone()).collect();
-                let res =
-                    tree.check_range_proof(&root, &leaf_hashes, &mut proof.take_siblings(), j);
+                let leaf_hashes: Vec<_> = tree.leaves()[j..i].iter().map(|l| l.hash).collect();
+                let res = tree.check_range_proof(&root, &leaf_hashes, proof.siblings(), j);
                 if i != j {
                     dbg!(i, j, &res);
                     println!("{:?}", &leaf_hashes);
@@ -505,19 +494,15 @@ mod tests {
             let _ = tree.push_leaf(x.to_be_bytes().as_ref(), namespace);
         }
         let root = tree.root();
-        let leaf_hashes: Vec<_> = tree.leaves().iter().map(|x| x.hash.clone()).collect();
+        let leaf_hashes: Vec<_> = tree.leaves().iter().map(|x| x.hash).collect();
 
         // For each potential range of size four, build and check a range proof
         for i in 0..=28 {
             let leaf_range = i..i + 4;
             let proof = tree.build_range_proof(leaf_range.clone());
 
-            let result = tree.check_range_proof(
-                &root,
-                &leaf_hashes[leaf_range],
-                &mut proof.take_siblings(),
-                i,
-            );
+            let result =
+                tree.check_range_proof(&root, &leaf_hashes[leaf_range], proof.siblings(), i);
             assert!(result.is_ok());
 
             // We've set up our tree to have four leaves in each namespace, so a
@@ -601,7 +586,7 @@ mod tests {
             };
 
             assert!(tree
-                .verify_namespace(&root, &raw_leaves[range.clone()], *namespace, proof)
+                .verify_namespace(&root, &raw_leaves[range.clone()], *namespace, &proof)
                 .is_ok());
         }
 

--- a/src/namespaced_hash.rs
+++ b/src/namespaced_hash.rs
@@ -77,8 +77,8 @@ impl<const NS_ID_SIZE: usize> MerkleHash for NamespacedSha2Hasher<NS_ID_SIZE> {
 
         let mut output = NamespacedHash::with_min_and_max_ns(min_ns, max_ns);
 
-        hasher.update(&left.iter().copied().collect::<Vec<_>>());
-        hasher.update(&right.iter().copied().collect::<Vec<_>>());
+        hasher.update(&left.iter().collect::<Vec<_>>());
+        hasher.update(&right.iter().collect::<Vec<_>>());
 
         output.set_hash(hasher.finalize().as_ref());
         output
@@ -139,7 +139,7 @@ impl<const NS_ID_SIZE: usize> TryFrom<&[u8]> for NamespaceId<NS_ID_SIZE> {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Eq, Hash)]
+#[derive(Debug, PartialEq, Copy, Clone, Eq, Hash)]
 #[cfg_attr(any(test, feature = "borsh"), derive(borsh::BorshSerialize))]
 pub struct NamespacedHash<const NS_ID_SIZE: usize> {
     min_ns: NamespaceId<NS_ID_SIZE>,
@@ -176,7 +176,7 @@ impl<const NS_ID_SIZE: usize> serde::Serialize for NamespacedHash<NS_ID_SIZE> {
         use serde::ser::SerializeTuple;
         let mut seq = serializer.serialize_tuple(NamespacedHash::<NS_ID_SIZE>::size())?;
         for byte in self.iter() {
-            seq.serialize_element(byte)?;
+            seq.serialize_element(&byte)?;
         }
         seq.end()
     }
@@ -313,12 +313,12 @@ impl<const NS_ID_SIZE: usize> NamespacedHash<NS_ID_SIZE> {
         output
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &u8> {
+    pub fn iter(&self) -> impl Iterator<Item = u8> {
         self.min_ns
             .0
-            .iter()
-            .chain(self.max_ns.0.iter())
-            .chain(self.hash.iter())
+            .into_iter()
+            .chain(self.max_ns.0.into_iter())
+            .chain(self.hash.into_iter())
     }
 }
 

--- a/src/namespaced_hash.rs
+++ b/src/namespaced_hash.rs
@@ -139,7 +139,7 @@ impl<const NS_ID_SIZE: usize> TryFrom<&[u8]> for NamespaceId<NS_ID_SIZE> {
     }
 }
 
-#[derive(Debug, PartialEq, Copy, Clone, Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Eq, Hash)]
 #[cfg_attr(any(test, feature = "borsh"), derive(borsh::BorshSerialize))]
 pub struct NamespacedHash<const NS_ID_SIZE: usize> {
     min_ns: NamespaceId<NS_ID_SIZE>,

--- a/src/nmt_proof.rs
+++ b/src/nmt_proof.rs
@@ -29,12 +29,13 @@ pub enum NamespaceProof<M: MerkleHash, const NS_ID_SIZE: usize> {
     },
 }
 
-impl<M: NamespaceMerkleHasher<Output = NamespacedHash<NS_ID_SIZE>>, const NS_ID_SIZE: usize>
-    NamespaceProof<M, NS_ID_SIZE>
+impl<M, const NS_ID_SIZE: usize> NamespaceProof<M, NS_ID_SIZE>
+where
+    M: NamespaceMerkleHasher<Output = NamespacedHash<NS_ID_SIZE>>,
 {
     /// Verify that the provided *raw* leaves occur in the provided namespace, using this proof
     pub fn verify_complete_namespace(
-        self,
+        &self,
         root: &NamespacedHash<NS_ID_SIZE>,
         raw_leaves: &[impl AsRef<[u8]>],
         namespace: NamespaceId<NS_ID_SIZE>,
@@ -47,33 +48,30 @@ impl<M: NamespaceMerkleHasher<Output = NamespacedHash<NS_ID_SIZE>>, const NS_ID_
 
     /// Verify a range proof
     pub fn verify_range(
-        self,
+        &self,
         root: &NamespacedHash<NS_ID_SIZE>,
         raw_leaves: &[impl AsRef<[u8]>],
         leaf_namespace: NamespaceId<NS_ID_SIZE>,
     ) -> Result<(), RangeProofError> {
+        if self.is_of_absence() {
+            return Err(RangeProofError::MalformedProof);
+        };
+
+        let leaf_hashes: Vec<_> = raw_leaves
+            .iter()
+            .map(|data| NamespacedHash::hash_leaf(data.as_ref(), leaf_namespace))
+            .collect();
         let tree = NamespaceMerkleTree::<NoopDb, M, NS_ID_SIZE>::with_hasher(
             M::with_ignore_max_ns(self.ignores_max_ns()),
         );
-        if let NamespaceProof::PresenceProof {
-            proof: Proof {
-                mut siblings,
-                start_idx,
-            },
-            ..
-        } = self
-        {
-            let leaf_hashes: Vec<NamespacedHash<NS_ID_SIZE>> = raw_leaves
-                .iter()
-                .map(|data| NamespacedHash::hash_leaf(data.as_ref(), leaf_namespace))
-                .collect();
-            tree.inner
-                .check_range_proof(root, &leaf_hashes, &mut siblings, start_idx as usize)?;
-            Ok(())
-        } else {
-            Err(RangeProofError::MalformedProof)
-        }
+        tree.inner.check_range_proof(
+            root,
+            &leaf_hashes,
+            self.siblings(),
+            self.start_idx() as usize,
+        )
     }
+
     pub fn convert_to_absence_proof(&mut self, leaf: NamespacedHash<NS_ID_SIZE>) {
         match self {
             NamespaceProof::AbsenceProof { .. } => {}
@@ -91,39 +89,21 @@ impl<M: NamespaceMerkleHasher<Output = NamespacedHash<NS_ID_SIZE>>, const NS_ID_
         }
     }
 
-    pub fn siblings(&self) -> &Vec<NamespacedHash<NS_ID_SIZE>> {
+    fn merkle_proof(&self) -> &Proof<M> {
         match self {
-            NamespaceProof::AbsenceProof {
-                proof: Proof { siblings, .. },
-                ..
-            } => siblings,
-            NamespaceProof::PresenceProof {
-                proof: Proof { siblings, .. },
-                ..
-            } => siblings,
+            NamespaceProof::AbsenceProof { proof, .. }
+            | NamespaceProof::PresenceProof { proof, .. } => proof,
         }
     }
 
-    pub fn start_idx(&self) -> u32 {
-        match self {
-            NamespaceProof::AbsenceProof {
-                proof:
-                    Proof {
-                        siblings: _,
-                        start_idx,
-                    },
-                ..
-            } => *start_idx,
-            NamespaceProof::PresenceProof {
-                proof:
-                    Proof {
-                        siblings: _,
-                        start_idx,
-                    },
-                ..
-            } => *start_idx,
-        }
+    pub fn siblings(&self) -> &[NamespacedHash<NS_ID_SIZE>] {
+        self.merkle_proof().siblings()
     }
+
+    pub fn start_idx(&self) -> u32 {
+        self.merkle_proof().start_idx()
+    }
+
     pub fn leftmost_right_sibling(&self) -> Option<&NamespacedHash<NS_ID_SIZE>> {
         let siblings = self.siblings();
         let num_left_siblings = compute_num_left_siblings(self.start_idx() as usize);
@@ -142,32 +122,10 @@ impl<M: NamespaceMerkleHasher<Output = NamespacedHash<NS_ID_SIZE>>, const NS_ID_
         None
     }
 
-    #[cfg(test)]
-    pub fn take_siblings(self) -> Vec<NamespacedHash<NS_ID_SIZE>> {
-        match self {
-            Self::AbsenceProof {
-                proof: Proof { siblings, .. },
-                ..
-            } => siblings,
-            Self::PresenceProof {
-                proof: Proof { siblings, .. },
-                ..
-            } => siblings,
-        }
-    }
-
     fn ignores_max_ns(&self) -> bool {
         match self {
-            Self::AbsenceProof {
-                proof: _,
-                ignore_max_ns,
-                ..
-            } => *ignore_max_ns,
-            Self::PresenceProof {
-                proof: _,
-                ignore_max_ns,
-                ..
-            } => *ignore_max_ns,
+            Self::AbsenceProof { ignore_max_ns, .. }
+            | Self::PresenceProof { ignore_max_ns, .. } => *ignore_max_ns,
         }
     }
 
@@ -176,5 +134,9 @@ impl<M: NamespaceMerkleHasher<Output = NamespacedHash<NS_ID_SIZE>>, const NS_ID_
             Self::AbsenceProof { .. } => true,
             Self::PresenceProof { .. } => false,
         }
+    }
+
+    pub fn is_of_presence(&self) -> bool {
+        !self.is_of_absence()
     }
 }

--- a/src/simple_merkle/proof.rs
+++ b/src/simple_merkle/proof.rs
@@ -1,5 +1,5 @@
 use super::{
-    db::MemDb,
+    db::NoopDb,
     error::RangeProofError,
     tree::{MerkleHash, MerkleTree},
     utils::compute_num_left_siblings,
@@ -26,19 +26,12 @@ where
 {
     /// Verify a range proof
     pub fn verify_range(
-        mut self,
+        &self,
         root: &M::Output,
         leaf_hashes: &[M::Output],
     ) -> Result<(), RangeProofError> {
-        let tree = MerkleTree::<MemDb<M::Output>, M>::new();
-
-        tree.check_range_proof(
-            root,
-            leaf_hashes,
-            &mut self.siblings,
-            self.start_idx as usize,
-        )?;
-        Ok(())
+        let tree = MerkleTree::<NoopDb, M>::new();
+        tree.check_range_proof(root, leaf_hashes, self.siblings(), self.start_idx as usize)
     }
 
     pub fn siblings(&self) -> &Vec<M::Output> {
@@ -64,10 +57,5 @@ where
             return Some(&siblings[num_left_siblings - 1]);
         }
         None
-    }
-
-    #[cfg(test)]
-    pub fn take_siblings(self) -> Vec<M::Output> {
-        self.siblings
     }
 }


### PR DESCRIPTION
Mainly just a performance and qol changes.

`NamespacedHash`and hasher's `M::Output` can implement `Copy` as hashes are always of constant size.

`verify_complete_namespace` and `verify_range` now works by reference, which allows avoiding `Clone`s when one wants to verify the proof and still keep it around.

~~The way it works is that instead of recursively taking out the hashes from siblings while calculating the root, we allocate a new vector of references to the siblings that is reduced. That needs much lower alloc as size of ref is lower than the size of hash and when the hash is taken from that vec, it's just copied into the hasher.~~

Found even a nicer way, using the `slice_take_last` allows for not allocating at all, so whole proof verification by a reference is for free