### PR TITLE
nostd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,16 +6,17 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sha2 = "0.10.6"
-bytes = "1"
+sha2 = { version = "0.10.6", default-features = false }
+bytes = { version = "1", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 borsh = { version = "0.10.0", optional = true }
 
 [dev-dependencies]
-borsh = { version = "0.10.0" } 
+borsh = { version = "0.10.0" }
 serde_json = "1.0.96"
-postcard = { version = "1.0.4", features = ["use-std"] } 
+postcard = { version = "1.0.4" }
 
 [features]
-default = []
-serde = ["dep:serde"]
+default = ["std"]
+serde = ["dep:serde", "postcard/use-std"]
+std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,9 +541,6 @@ mod tests {
             let (leaves, proof) = tree.get_namespace_with_proof(namespace);
 
             let pf = proof.verify_complete_namespace(&root, &leaves, namespace);
-            if pf.is_err() {
-                panic!("{:?} {:?} {:?}", &pf, namespace, &leaves);
-            }
             assert!(pf.is_ok());
         }
     }
@@ -614,9 +611,6 @@ mod tests {
             let namespace = ns_id_from_u64(nid);
             let (leaves, proof) = tree.get_namespace_with_proof(namespace);
             let pf = proof.verify_complete_namespace(&root, &leaves, namespace);
-            if pf.is_err() {
-                panic!("{:?} {:?} {:?}", &pf, namespace, &leaves);
-            }
             assert!(pf.is_ok());
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,25 @@
-use std::{collections::HashMap, ops::Range};
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+mod maybestd {
+    #[cfg(not(feature = "std"))]
+    pub use alloc::{boxed, collections, format, string, vec};
+    #[cfg(not(feature = "std"))]
+    pub use core::{cmp, fmt, hash, marker, mem, ops};
+    #[cfg(feature = "std")]
+    pub use std::{boxed, cmp, collections, fmt, format, hash, marker, mem, ops, string, vec};
+
+    pub mod hash_or_btree_map {
+        #[cfg(not(feature = "std"))]
+        pub use alloc::collections::btree_map::{BTreeMap as Map, Entry};
+        #[cfg(feature = "std")]
+        pub use std::collections::hash_map::{Entry, HashMap as Map};
+    }
+}
+
+use crate::maybestd::{hash_or_btree_map, ops::Range, vec::Vec};
 
 pub use nmt_proof::NamespaceProof;
 use simple_merkle::{
@@ -56,7 +77,7 @@ fn check_proof_completeness<const NS_ID_SIZE: usize>(
 }
 
 pub struct NamespaceMerkleTree<Db, M: MerkleHash, const NS_ID_SIZE: usize> {
-    namespace_ranges: HashMap<NamespaceId<NS_ID_SIZE>, Range<usize>>,
+    namespace_ranges: hash_or_btree_map::Map<NamespaceId<NS_ID_SIZE>, Range<usize>>,
     highest_ns: NamespaceId<NS_ID_SIZE>,
     ignore_max_ns: bool,
     inner: MerkleTree<Db, M>,
@@ -96,10 +117,10 @@ where
 
         let leaves_len = self.leaves().len();
         match self.namespace_ranges.entry(namespace) {
-            std::collections::hash_map::Entry::Occupied(entry) => {
+            crate::maybestd::hash_or_btree_map::Entry::Occupied(entry) => {
                 entry.into_mut().end = leaves_len;
             }
-            std::collections::hash_map::Entry::Vacant(entry) => {
+            crate::maybestd::hash_or_btree_map::Entry::Vacant(entry) => {
                 entry.insert(leaves_len - 1..leaves_len);
             }
         }
@@ -353,6 +374,7 @@ pub enum RangeProofType {
 
 #[cfg(test)]
 mod tests {
+    use crate::maybestd::{format, vec::Vec};
     use crate::{
         namespaced_hash::{NamespaceId, NamespacedSha2Hasher},
         nmt_proof::NamespaceProof,
@@ -463,8 +485,6 @@ mod tests {
                     tree.leaves()[j..i].iter().map(|l| l.hash.clone()).collect();
                 let res = tree.check_range_proof(&root, &leaf_hashes, proof.siblings(), j);
                 if i != j {
-                    dbg!(i, j, &res);
-                    println!("{:?}", &leaf_hashes);
                     assert!(res.is_ok());
                     assert!(res.unwrap() == RangeProofType::Complete)
                 } else {
@@ -519,12 +539,10 @@ mod tests {
         for nid in 0..100u64 {
             let namespace = ns_id_from_u64(nid);
             let (leaves, proof) = tree.get_namespace_with_proof(namespace);
-            println!("Poof: {:?}", &proof);
 
             let pf = proof.verify_complete_namespace(&root, &leaves, namespace);
             if pf.is_err() {
-                dbg!(&pf, namespace);
-                println!("{:?}", &leaves);
+                panic!("{:?} {:?} {:?}", &pf, namespace, &leaves);
             }
             assert!(pf.is_ok());
         }
@@ -595,12 +613,9 @@ mod tests {
         for nid in 0..100u64 {
             let namespace = ns_id_from_u64(nid);
             let (leaves, proof) = tree.get_namespace_with_proof(namespace);
-            println!("Poof: {:?}", &proof);
-
             let pf = proof.verify_complete_namespace(&root, &leaves, namespace);
             if pf.is_err() {
-                dbg!(&pf, namespace);
-                println!("{:?}", &leaves);
+                panic!("{:?} {:?} {:?}", &pf, namespace, &leaves);
             }
             assert!(pf.is_ok());
         }

--- a/src/nmt_proof.rs
+++ b/src/nmt_proof.rs
@@ -1,3 +1,4 @@
+use crate::maybestd::{mem, vec::Vec};
 use crate::{
     namespaced_hash::{NamespaceId, NamespaceMerkleHasher, NamespacedHash},
     simple_merkle::{
@@ -79,7 +80,7 @@ where
                 proof,
                 ignore_max_ns,
             } => {
-                let pf = std::mem::take(proof);
+                let pf = mem::take(proof);
                 *self = Self::AbsenceProof {
                     proof: pf,
                     ignore_max_ns: *ignore_max_ns,

--- a/src/simple_merkle/db.rs
+++ b/src/simple_merkle/db.rs
@@ -1,20 +1,32 @@
-use std::{collections::HashMap, hash::Hash};
+use crate::maybestd::{hash::Hash, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+trait HashType: Eq + Hash + crate::maybestd::cmp::Ord {}
+
+#[cfg(not(feature = "std"))]
+impl<H: Eq + Hash + Ord> HashType for H {}
+
+#[cfg(feature = "std")]
+trait HashType: Eq + Hash {}
+
+#[cfg(feature = "std")]
+impl<H: Eq + Hash> HashType for H {}
 
 #[derive(Default)]
-pub struct MemDb<H>(HashMap<H, Node<H>>);
+pub struct MemDb<H>(crate::maybestd::hash_or_btree_map::Map<H, Node<H>>);
 
-impl<H: Eq + Hash> PreimageReader<H> for MemDb<H> {
+impl<H: HashType> PreimageReader<H> for MemDb<H> {
     fn get(&self, image: &H) -> Option<&Node<H>> {
         self.0.get(image)
     }
 }
-impl<H: Eq + Hash> PreimageWriter<H> for MemDb<H> {
+impl<H: HashType> PreimageWriter<H> for MemDb<H> {
     fn put(&mut self, image: H, preimage: Node<H>) {
         self.0.insert(image, preimage);
     }
 }
 
-impl<H: Default + Eq + Hash> PreimageDb<H> for MemDb<H> {}
+impl<H: Default + HashType> PreimageDb<H> for MemDb<H> {}
 
 #[derive(Clone)]
 pub struct LeafWithHash<H> {

--- a/src/simple_merkle/proof.rs
+++ b/src/simple_merkle/proof.rs
@@ -4,6 +4,7 @@ use super::{
     tree::{MerkleHash, MerkleTree},
     utils::compute_num_left_siblings,
 };
+use crate::maybestd::vec::Vec;
 
 /// A proof of some statement about a namespaced merkle tree.
 ///

--- a/src/simple_merkle/tree.rs
+++ b/src/simple_merkle/tree.rs
@@ -44,16 +44,30 @@ impl<Db: PreimageDb<<M as MerkleHash>::Output>, M: MerkleHash> Default for Merkl
 }
 
 pub trait MerkleHash: Default {
-    #[cfg(not(feature = "serde"))]
+    #[cfg(all(not(feature = "serde"), feature = "std"))]
+    type Output: Debug + PartialEq + Eq + Clone + Default + Hash;
+
+    #[cfg(all(not(feature = "serde"), not(feature = "std")))]
     type Output: Debug + PartialEq + Eq + Clone + Default + Hash + Ord;
 
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "serde", not(feature = "std")))]
     type Output: Debug
         + PartialEq
         + Eq
         + Clone
         + Default
         + Hash
+        + serde::Serialize
+        + serde::de::DeserializeOwned;
+
+    #[cfg(all(feature = "serde", feature = "std"))]
+    type Output: Debug
+        + PartialEq
+        + Eq
+        + Clone
+        + Default
+        + Hash
+        + Ord
         + serde::Serialize
         + serde::de::DeserializeOwned;
 

--- a/src/simple_merkle/tree.rs
+++ b/src/simple_merkle/tree.rs
@@ -2,9 +2,7 @@ use super::db::{LeafWithHash, Node, PreimageDb};
 use super::error::RangeProofError;
 use super::proof::Proof;
 use super::utils::{compute_num_left_siblings, compute_tree_size};
-use std::fmt::Debug;
-use std::hash::Hash;
-use std::ops::Range;
+use crate::maybestd::{boxed::Box, fmt::Debug, hash::Hash, ops::Range, vec::Vec};
 
 /// Manually implement the method we need from #[feature(slice_take)] to
 /// allow building with stable;
@@ -47,7 +45,7 @@ impl<Db: PreimageDb<<M as MerkleHash>::Output>, M: MerkleHash> Default for Merkl
 
 pub trait MerkleHash: Default {
     #[cfg(not(feature = "serde"))]
-    type Output: Debug + PartialEq + Eq + Clone + Default + Hash;
+    type Output: Debug + PartialEq + Eq + Clone + Default + Hash + Ord;
 
     #[cfg(feature = "serde")]
     type Output: Debug
@@ -72,7 +70,7 @@ where
 {
     pub fn new() -> Self {
         Self {
-            leaves: vec![],
+            leaves: Vec::new(),
             db: Default::default(),
             root: Some(M::EMPTY_ROOT),
             visitor: Box::new(|_| {}),
@@ -82,7 +80,7 @@ where
 
     pub fn with_hasher(hasher: M) -> Self {
         Self {
-            leaves: vec![],
+            leaves: Vec::new(),
             db: Default::default(),
             root: Some(M::EMPTY_ROOT),
             visitor: Box::new(|_| {}),


### PR DESCRIPTION
Fixes https://github.com/Sovereign-Labs/nmt-rs/issues/15

This changeset aims to preserve using the HashMap in the std environment while in no_std it swaps it with BTreeMap. As a result, under the no_std environment additional bounds for `Ord` are added for the hash type.