### PR TITLE
Prevent panics in NamespacedHash.set_hash

### DIFF
--- a/src/namespaced_hash.rs
+++ b/src/namespaced_hash.rs
@@ -295,7 +295,7 @@ impl<const NS_ID_SIZE: usize> NamespacedHash<NS_ID_SIZE> {
         self.hash
     }
 
-    fn set_hash(&mut self, new_hash: &[u8]) {
+    fn set_hash(&mut self, new_hash: &[u8; HASH_LEN]) {
         self.hash.copy_from_slice(new_hash)
     }
 


### PR DESCRIPTION
Statically check the arguments to NamespacedHash.set_hash to avoid panics. Closes #9 