### PR TITLE
Cleanup for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 name = "nmt-rs"
 version = "0.1.0"
 edition = "2021"
+description = "A namespaced merkle tree compatible with Celestia"
+license = "MIT OR Apache-2.0"
+authors = ["Sovereign Labs <info@sovereign.xyz>"]
+homepage = "https://www.sovereign.xyz"
+
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/namespaced_hash.rs
+++ b/src/namespaced_hash.rs
@@ -293,16 +293,6 @@ impl<const NS_ID_SIZE: usize> Default for NamespacedHash<NS_ID_SIZE> {
 }
 
 impl<const NS_ID_SIZE: usize> NamespacedHash<NS_ID_SIZE> {
-    // /// The root of the empty merkle tree
-    // pub const EMPTY_ROOT: NamespacedHash<NS_ID_SIZE> = Self {
-    //     min_ns: NamespaceId([0; NS_ID_SIZE]),
-    //     max_ns: NamespaceId([0; NS_ID_SIZE]),
-    //     hash: [
-    //         227, 176, 196, 66, 152, 252, 28, 20, 154, 251, 244, 200, 153, 111, 185, 36, 39, 174,
-    //         65, 228, 100, 155, 147, 76, 164, 149, 153, 27, 120, 82, 184, 85,
-    //     ],
-    // };
-
     /// Returns the size of the hash in bytes
     pub const fn size() -> usize {
         2 * NS_ID_SIZE + HASH_LEN

--- a/src/namespaced_hash.rs
+++ b/src/namespaced_hash.rs
@@ -60,7 +60,8 @@ impl<const NS_ID_SIZE: usize> Default for NamespacedSha2Hasher<NS_ID_SIZE> {
     }
 }
 
-/// An addon for
+/// An extension of [`MerkleHash`] indicating the the hasher is namespace aware. This allows for the creation of
+/// namespaced merkle trees and namespaced merkle proofs.
 pub trait NamespaceMerkleHasher<const NS_ID_SIZE: usize>: MerkleHash {
     /// Create a new hasher which ignores the max namespace
     fn with_ignore_max_ns(ignore_max_ns: bool) -> Self;

--- a/src/namespaced_hash.rs
+++ b/src/namespaced_hash.rs
@@ -15,7 +15,9 @@ pub struct NamespacedSha2Hasher<const NS_ID_SIZE: usize> {
     _data: PhantomData<[u8; NS_ID_SIZE]>,
 }
 
-impl<const NS_ID_SIZE: usize> NamespaceMerkleHasher for NamespacedSha2Hasher<NS_ID_SIZE> {
+impl<const NS_ID_SIZE: usize> NamespaceMerkleHasher<NS_ID_SIZE>
+    for NamespacedSha2Hasher<NS_ID_SIZE>
+{
     fn with_ignore_max_ns(ignore_max_ns: bool) -> Self {
         Self {
             ignore_max_ns,
@@ -25,6 +27,13 @@ impl<const NS_ID_SIZE: usize> NamespaceMerkleHasher for NamespacedSha2Hasher<NS_
 
     fn ignores_max_ns(&self) -> bool {
         self.ignore_max_ns
+    }
+
+    fn hash_leaf_with_namespace(
+        data: &[u8],
+        namespace: NamespaceId<NS_ID_SIZE>,
+    ) -> <Self as MerkleHash>::Output {
+        NamespacedHash::hash_leaf(data, namespace)
     }
 }
 
@@ -37,9 +46,13 @@ impl<const NS_ID_SIZE: usize> Default for NamespacedSha2Hasher<NS_ID_SIZE> {
     }
 }
 
-pub trait NamespaceMerkleHasher: MerkleHash {
+pub trait NamespaceMerkleHasher<const NS_ID_SIZE: usize>: MerkleHash {
     fn with_ignore_max_ns(ignore_max_ns: bool) -> Self;
     fn ignores_max_ns(&self) -> bool;
+    fn hash_leaf_with_namespace(
+        data: &[u8],
+        namespace: NamespaceId<NS_ID_SIZE>,
+    ) -> <Self as MerkleHash>::Output;
 }
 
 impl<const NS_ID_SIZE: usize> MerkleHash for NamespacedSha2Hasher<NS_ID_SIZE> {

--- a/src/nmt_proof.rs
+++ b/src/nmt_proof.rs
@@ -82,7 +82,10 @@ where
 
         let leaf_hashes: Vec<_> = raw_leaves
             .iter()
-            .map(|data| NamespacedHash::hash_leaf(data.as_ref(), leaf_namespace))
+            .map(|data| {
+                M::with_ignore_max_ns(self.ignores_max_ns())
+                    .hash_leaf_with_namespace(data.as_ref(), leaf_namespace)
+            })
             .collect();
         let tree = NamespaceMerkleTree::<NoopDb, M, NS_ID_SIZE>::with_hasher(
             M::with_ignore_max_ns(self.ignores_max_ns()),

--- a/src/nmt_proof.rs
+++ b/src/nmt_proof.rs
@@ -32,7 +32,7 @@ pub enum NamespaceProof<M: MerkleHash, const NS_ID_SIZE: usize> {
 
 impl<M, const NS_ID_SIZE: usize> NamespaceProof<M, NS_ID_SIZE>
 where
-    M: NamespaceMerkleHasher<Output = NamespacedHash<NS_ID_SIZE>>,
+    M: NamespaceMerkleHasher<NS_ID_SIZE, Output = NamespacedHash<NS_ID_SIZE>>,
 {
     /// Verify that the provided *raw* leaves occur in the provided namespace, using this proof
     pub fn verify_complete_namespace(

--- a/src/nmt_proof.rs
+++ b/src/nmt_proof.rs
@@ -1,3 +1,7 @@
+//! Adds "namespacing" semantics to proofs for the simple merkle tree, enabling
+//! consumers to check that
+//! - A range of leaves forms a complete namespace
+//! - A range of leaves all exists in the same namespace
 use crate::maybestd::{mem, vec::Vec};
 use crate::{
     namespaced_hash::{NamespaceId, NamespaceMerkleHasher, NamespacedHash},
@@ -19,13 +23,21 @@ use crate::{
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum NamespaceProof<M: MerkleHash, const NS_ID_SIZE: usize> {
+    /// A proof that some item is absent from the tree
     AbsenceProof {
+        /// The range proof against the inner merkle tree
         proof: Proof<M>,
+        /// Whether to treat the maximum possible namespace as a special marker value and ignore it in computing namespace ranges
         ignore_max_ns: bool,
+        /// A leaf that *is* present in the tree, if the namespce being proven absent falls within
+        /// the namespace range covered by the root.
         leaf: Option<NamespacedHash<NS_ID_SIZE>>,
     },
+    /// A proof that some item is included in the tree
     PresenceProof {
+        /// The range proof against the inner merkle tree
         proof: Proof<M>,
+        /// Whether to treat the maximum possible namespace as a special marker value and ignore it in computing namespace ranges
         ignore_max_ns: bool,
     },
 }
@@ -34,7 +46,7 @@ impl<M, const NS_ID_SIZE: usize> NamespaceProof<M, NS_ID_SIZE>
 where
     M: NamespaceMerkleHasher<NS_ID_SIZE, Output = NamespacedHash<NS_ID_SIZE>>,
 {
-    /// Verify that the provided *raw* leaves occur in the provided namespace, using this proof
+    /// Verify that the provided *raw* leaves are a complete namespace. This may be a proof of presence or absence.
     pub fn verify_complete_namespace(
         &self,
         root: &NamespacedHash<NS_ID_SIZE>,
@@ -51,7 +63,7 @@ where
         tree.verify_namespace(root, raw_leaves, namespace, self)
     }
 
-    /// Verify a range proof
+    /// Verify a that the provided *raw* leaves are a (1) present and (2) form a contiguous subset of some namespace
     pub fn verify_range(
         &self,
         root: &NamespacedHash<NS_ID_SIZE>,
@@ -59,7 +71,9 @@ where
         leaf_namespace: NamespaceId<NS_ID_SIZE>,
     ) -> Result<(), RangeProofError> {
         if self.is_of_absence() {
-            return Err(RangeProofError::MalformedProof);
+            return Err(RangeProofError::MalformedProof(
+                "Cannot prove that a partial namespace is absent",
+            ));
         };
 
         if raw_leaves.len() != self.range_len() {
@@ -81,6 +95,7 @@ where
         )
     }
 
+    /// Convert a proof of the presence of some leaf to the proof of the absence of another leaf
     pub fn convert_to_absence_proof(&mut self, leaf: NamespacedHash<NS_ID_SIZE>) {
         match self {
             NamespaceProof::AbsenceProof { .. } => {}
@@ -105,22 +120,27 @@ where
         }
     }
 
+    /// Returns the siblings provided as part of the proof
     pub fn siblings(&self) -> &[NamespacedHash<NS_ID_SIZE>] {
         self.merkle_proof().siblings()
     }
 
+    /// Returns the index of the first leaf in the proof
     pub fn start_idx(&self) -> u32 {
         self.merkle_proof().start_idx()
     }
 
+    /// Returns the index *after* the last leaf in the proof
     pub fn end_idx(&self) -> u32 {
         self.merkle_proof().end_idx()
     }
 
+    /// Returns the number of leaves covered by the proof
     fn range_len(&self) -> usize {
         self.merkle_proof().range_len()
     }
 
+    /// Returns the leftmost node to the right of the proven range, if one exists
     pub fn leftmost_right_sibling(&self) -> Option<&NamespacedHash<NS_ID_SIZE>> {
         let siblings = self.siblings();
         let num_left_siblings = compute_num_left_siblings(self.start_idx() as usize);
@@ -130,6 +150,7 @@ where
         None
     }
 
+    /// Returns the rightmost node to the left of the proven range, if one exists
     pub fn rightmost_left_sibling(&self) -> Option<&NamespacedHash<NS_ID_SIZE>> {
         let siblings = self.siblings();
         let num_left_siblings = compute_num_left_siblings(self.start_idx() as usize);
@@ -146,6 +167,7 @@ where
         }
     }
 
+    /// Returns true if the proof is an absence proof
     pub fn is_of_absence(&self) -> bool {
         match self {
             Self::AbsenceProof { .. } => true,
@@ -153,6 +175,7 @@ where
         }
     }
 
+    /// Returns true if the proof is a presence proof
     pub fn is_of_presence(&self) -> bool {
         !self.is_of_absence()
     }

--- a/src/simple_merkle/db.rs
+++ b/src/simple_merkle/db.rs
@@ -34,23 +34,34 @@ impl<H: HashType> PreimageWriter<H> for MemDb<H> {
 
 impl<H: Default + HashType> PreimageDb<H> for MemDb<H> {}
 
-/// A
+/// The raw data of the leaf, together with its hash under some [`MerkleHash`]er
 #[derive(Clone)]
 pub struct LeafWithHash<H: MerkleHash> {
     data: Vec<u8>,
     hash: H::Output,
 }
 
-impl<H: MerkleHash> LeafWithHash<H> {
+impl<H: MerkleHash + Default> LeafWithHash<H> {
+    /// Construct a [`LeafWithHash`] by hashing the provided data
     pub fn new(data: Vec<u8>) -> Self {
         let hash = H::default().hash_leaf(&data);
         Self { data, hash }
     }
+}
 
+impl<H: MerkleHash> LeafWithHash<H> {
+    /// Construct a [`LeafWithHash`] by hashing the provided data
+    pub fn with_hasher(data: Vec<u8>, hasher: &H) -> Self {
+        let hash = hasher.hash_leaf(&data);
+        Self { data, hash }
+    }
+
+    /// Returns the raw data from the leaf
     pub fn data(&self) -> &[u8] {
         &self.data
     }
 
+    /// Returns the hash of the leaf data
     pub fn hash(&self) -> &H::Output {
         &self.hash
     }
@@ -62,32 +73,46 @@ impl<
     > LeafWithHash<M>
 {
     /// Create a new leaf with the provided namespace. Only available if the hasher supports namespacing.
-    pub fn new_with_namespace(data: Vec<u8>, namespace: NamespaceId<NS_ID_SIZE>) -> Self {
-        let hash = M::hash_leaf_with_namespace(&data, namespace);
+    pub fn new_with_namespace(
+        data: Vec<u8>,
+        namespace: NamespaceId<NS_ID_SIZE>,
+        ignore_max_ns: bool,
+    ) -> Self {
+        let hasher = M::with_ignore_max_ns(ignore_max_ns);
+        let hash = hasher.hash_leaf_with_namespace(&data, namespace);
         Self { data, hash }
     }
 }
 
+/// A node of a merkle tree
 #[derive(PartialEq, Clone, Debug)]
 pub enum Node<H> {
+    /// A leaf node contains raw data
     Leaf(Vec<u8>),
+    /// An inner node is the concatention of two child nodes
     Inner(H, H),
 }
 
+/// The reader trait for a data store that maps hashes to preimages
 pub trait PreimageReader<H> {
+    /// Get the preimage of a given hash
     fn get(&self, image: &H) -> Option<&Node<H>>;
 }
 
+/// The writer trait for a data store that maps hashes to preimages
 pub trait PreimageWriter<H> {
+    /// Store the preimage of a given hash
     fn put(&mut self, image: H, preimage: Node<H>);
 }
 
+/// A trait representing read and write access to data store that maps hashes to their preimages
 pub trait PreimageDb<H>: PreimageReader<H> + PreimageWriter<H> + Default {}
 
 /// A PreimageDB that drops all stored items. Should only be used in trees that
-/// do not create proofs (i.e. trees used only for proof  verification)
+/// do not create proofs (i.e. trees used only for proof verification)
 #[derive(Default)]
 pub struct NoopDb;
+
 impl<H: Eq + Hash> PreimageReader<H> for NoopDb {
     fn get(&self, _image: &H) -> Option<&Node<H>> {
         None

--- a/src/simple_merkle/db.rs
+++ b/src/simple_merkle/db.rs
@@ -1,4 +1,9 @@
-use crate::maybestd::{hash::Hash, vec::Vec};
+use crate::{
+    maybestd::{hash::Hash, vec::Vec},
+    NamespaceId, NamespaceMerkleHasher, NamespacedHash,
+};
+
+use super::tree::MerkleHash;
 
 #[cfg(not(feature = "std"))]
 trait HashType: Eq + Hash + crate::maybestd::cmp::Ord {}
@@ -12,6 +17,7 @@ trait HashType: Eq + Hash {}
 #[cfg(feature = "std")]
 impl<H: Eq + Hash> HashType for H {}
 
+/// Maintains a mapping from hash to preimage in memory. Backed by a [`crate::maybestd::hash_or_btree_map::Map<H, Node<H>>`]
 #[derive(Default)]
 pub struct MemDb<H>(crate::maybestd::hash_or_btree_map::Map<H, Node<H>>);
 
@@ -28,10 +34,38 @@ impl<H: HashType> PreimageWriter<H> for MemDb<H> {
 
 impl<H: Default + HashType> PreimageDb<H> for MemDb<H> {}
 
+/// A
 #[derive(Clone)]
-pub struct LeafWithHash<H> {
-    pub data: Vec<u8>,
-    pub hash: H,
+pub struct LeafWithHash<H: MerkleHash> {
+    data: Vec<u8>,
+    hash: H::Output,
+}
+
+impl<H: MerkleHash> LeafWithHash<H> {
+    pub fn new(data: Vec<u8>) -> Self {
+        let hash = H::default().hash_leaf(&data);
+        Self { data, hash }
+    }
+
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    pub fn hash(&self) -> &H::Output {
+        &self.hash
+    }
+}
+
+impl<
+        M: NamespaceMerkleHasher<NS_ID_SIZE, Output = NamespacedHash<NS_ID_SIZE>>,
+        const NS_ID_SIZE: usize,
+    > LeafWithHash<M>
+{
+    /// Create a new leaf with the provided namespace. Only available if the hasher supports namespacing.
+    pub fn new_with_namespace(data: Vec<u8>, namespace: NamespaceId<NS_ID_SIZE>) -> Self {
+        let hash = M::hash_leaf_with_namespace(&data, namespace);
+        Self { data, hash }
+    }
 }
 
 #[derive(PartialEq, Clone, Debug)]

--- a/src/simple_merkle/error.rs
+++ b/src/simple_merkle/error.rs
@@ -1,14 +1,22 @@
+/// An error that occurred while trying to check a claimed range proof for a merkle tree.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum RangeProofError {
+    /// The tree is not empty, but no leaves were provided. This proof is malformed - even proofs of absence must provide a leaf.
     NoLeavesProvided,
+    /// The proof is malformed - the number of leaves provided does not match the claimed size of the range
     WrongAmountOfLeavesProvided,
+    /// The claimed proof does not verify against the provided root
     InvalidRoot,
+    /// The claimed range was invalid because it left out a leaf
     MissingLeaf,
+    /// The proof is missing a node that was needed for verification
     MissingProofNode,
+    /// A claimed leaf was not actually present in the tree
     TreeDoesNotContainLeaf,
-    TreeIsEmpty,
+    /// The claimed tree exceeds the maximum allowed size (currently 2^32 leaves)
     TreeTooLarge,
     /// Indicates that the tree is not properly ordered by namespace
     MalformedTree,
-    MalformedProof,
+    /// A catch all error which indicates that the proof is malformed
+    MalformedProof(&'static str),
 }

--- a/src/simple_merkle/mod.rs
+++ b/src/simple_merkle/mod.rs
@@ -1,3 +1,5 @@
+//! Implements a simple [RFC 6962](https://www.rfc-editor.org/rfc/rfc6962#section-2.1) compatible merkle tree
+//! over an in-memory data store which maps preimages to hashes.
 pub mod db;
 pub mod error;
 pub mod proof;

--- a/src/simple_merkle/mod.rs
+++ b/src/simple_merkle/mod.rs
@@ -1,7 +1,13 @@
 //! Implements a simple [RFC 6962](https://www.rfc-editor.org/rfc/rfc6962#section-2.1) compatible merkle tree
 //! over an in-memory data store which maps preimages to hashes.
+
+/// Defines traits and types for storing hashes and preimages.
 pub mod db;
+/// Defines errors that might arise in proof verification.
 pub mod error;
+/// Defines proofs on the tree.
 pub mod proof;
+/// Defines the merkle tree itself.
 pub mod tree;
+/// Utilities for computing facts about trees from proofs.
 pub mod utils;

--- a/src/simple_merkle/proof.rs
+++ b/src/simple_merkle/proof.rs
@@ -19,7 +19,9 @@ use crate::maybestd::vec::Vec;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Proof<M: MerkleHash> {
+    /// The siblings to be used to build the path to the root.
     pub siblings: Vec<M::Output>,
+    /// The range of indices covered by the proof.
     pub range: Range<u32>,
 }
 
@@ -80,22 +82,27 @@ where
         )
     }
 
+    /// Returns the siblings provided as part of the proof.
     pub fn siblings(&self) -> &Vec<M::Output> {
         &self.siblings
     }
 
+    /// Returns the index of the first leaf covered by the proof.
     pub fn start_idx(&self) -> u32 {
         self.range.start
     }
 
+    /// Returns the index *after* the last leaf included in the proof.
     pub fn end_idx(&self) -> u32 {
         self.range.end
     }
 
+    /// Returns the length of the range covered by the proof.
     pub fn range_len(&self) -> usize {
         self.range.end.saturating_sub(self.range.start) as usize
     }
 
+    /// Returns the leftmost node to the right of the proven range, if one exists.
     pub fn leftmost_right_sibling(&self) -> Option<&M::Output> {
         let siblings = self.siblings();
         let num_left_siblings = compute_num_left_siblings(self.start_idx() as usize);
@@ -105,6 +112,7 @@ where
         None
     }
 
+    /// Returns the rightmost node to the left of the proven range, if one exists.
     pub fn rightmost_left_sibling(&self) -> Option<&M::Output> {
         let siblings = self.siblings();
         let num_left_siblings = compute_num_left_siblings(self.start_idx() as usize);


### PR DESCRIPTION
This PR performs some minor refactors to improve type-safety and adds missing docs. The four refactors are:
1. Make the fields of `LeafWithHash` private to ensure that leaves with invalid hashes cannot be constructed. 
2. Remove the "EMPTY_ROOT" constant from `NamespacedHash`, since the empty root depends on the hasher. This type is moved into the Hasher.
3. Actually use the saved `hasher` in the simple merkle tree, rather than (incorrectly) instantiating a new hasher for each operation. This ensures correct behavior for non-default hashers. 
4. Remove the requirement that all `MerkleHasher`s impement the `Default` trait 