### PR TITLE
Do not fail CI if coverage report upload fails

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -107,4 +107,4 @@ jobs:
         if: ${{ github.repository == 'Sovereign-Labs/nmt-rs' }}
         uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
This should make CI a little bit more stable