### PR TITLE
Theodore/proofnarrowing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nmt-rs"
-version = "0.2.1"
+version = "0.2.3"
 edition = "2021"
 description = "A namespaced merkle tree compatible with Celestia"
 license = "MIT OR Apache-2.0"
@@ -21,7 +21,7 @@ nmt-rs = { path = ".", features = ["borsh", "serde"] }
 borsh = { version = "1" }
 serde_json = "1.0.96"
 postcard = { version = "1.0.4", features = ["use-std"] }
-tendermint = { version = "0.35.0" }
+tendermint = { version = "0.39.1" }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ borsh = { version = "1" }
 serde_json = "1.0.96"
 postcard = { version = "1.0.4", features = ["use-std"] }
 tendermint = { version = "0.35.0" }
-paste = "1.0.15"
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ borsh = { version = "1" }
 serde_json = "1.0.96"
 postcard = { version = "1.0.4", features = ["use-std"] }
 tendermint = { version = "0.35.0" }
+paste = "1.0.15"
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This code has not been audited, and may contain critical vulnerabilities. Do not
 
 - [x] Verify namespace range proofs
 
+- [x] Narrow namespace range proofs: supply part of the range to generate a proof for the remaining sub-range
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,7 +429,6 @@ mod tests {
         simple_merkle::db::MemDb,
         NamespaceMerkleTree, NamespacedHash, RangeProofType, CELESTIA_NS_ID_SIZE,
     };
-    use paste::paste;
 
     type DefaultNmt<const NS_ID_SIZE: usize> = NamespaceMerkleTree<
         MemDb<NamespacedHash<NS_ID_SIZE>>,
@@ -649,23 +648,16 @@ mod tests {
         test_min_and_max_ns_against(&mut tree)
     }
 
-    macro_rules! make_narrowing_test {
-        ($($x:literal),*) => {
-            $(
-            paste! {
-                #[test]
-                fn [<test_range_proof_narrowing_ $x>]() {
-                    test_range_proof_narrowing_with_n_leaves::<8>($x);
-                    test_range_proof_narrowing_with_n_leaves::<17>($x);
-                    test_range_proof_narrowing_with_n_leaves::<24>($x);
-                    test_range_proof_narrowing_with_n_leaves::<CELESTIA_NS_ID_SIZE>($x);
-                    test_range_proof_narrowing_with_n_leaves::<32>($x);
-                }
-            })*
-        };
+    #[test]
+    fn test_range_proof_narrowing() {
+        for x in 0..20 {
+            test_range_proof_narrowing_with_n_leaves::<8>(x);
+            test_range_proof_narrowing_with_n_leaves::<17>(x);
+            test_range_proof_narrowing_with_n_leaves::<24>(x);
+            test_range_proof_narrowing_with_n_leaves::<CELESTIA_NS_ID_SIZE>(x);
+            test_range_proof_narrowing_with_n_leaves::<32>(x);
+        }
     }
-
-    make_narrowing_test!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 40);
 
     fn test_completeness_check_impl<const NS_ID_SIZE: usize>() {
         // Build a tree with 32 leaves spread evenly across 8 namespaces


### PR DESCRIPTION
Add proof narrowing capabilities to the tree: given a range proof, supply two sets of leafs (contiguous with the edges of the original range), to generate a proof for the remaining sub-range.

This feature is useful for generating proofs of individual blobs in a Celestia namespace using the full-namespace proof returned by the `GetSharesByNamespace` RPC call.