### PR TITLE
Make the MerkleTree Send

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nmt-rs"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 description = "A namespaced merkle tree compatible with Celestia"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -836,4 +836,11 @@ mod tests {
         test_namespace_verification_impl::<CELESTIA_NS_ID_SIZE>();
         test_namespace_verification_impl::<32>();
     }
+
+    #[allow(unused)]
+    fn compilation_test_nmt_is_send() {
+        fn is_send<T: Send>(_t: T) {}
+
+        is_send(DefaultNmt::<1>::new());
+    }
 }

--- a/src/simple_merkle/tree.rs
+++ b/src/simple_merkle/tree.rs
@@ -30,7 +30,7 @@ impl<T> TakeFirst<T> for [T] {
     }
 }
 
-type BoxedVisitor<M> = Box<dyn Fn(&<M as MerkleHash>::Output)>;
+type BoxedVisitor<M> = Box<dyn Fn(&<M as MerkleHash>::Output) + Send>;
 
 /// Helper data structure for immutable data used during proof narrowing recursion.
 /// All indices are relative to the leaves of the entire tree.


### PR DESCRIPTION
It looks like the tree is currently `!Send`, which means it cannot be passed into non local `Futures` or shared between threads. This PR makes it `Send`. It should be non-breaking change