### PR TITLE
Update actions used in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,17 +18,14 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
-          default: true
-          components: clippy, rustfmt
+          components: clippy
+          rustflags: -D warnings
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
-        with:
-          version: "v0.4.0"
+        uses: mozilla-actions/sccache-action@v0.0.8
       - name: Run cargo clippy
         run: cargo clippy --all-features --all-targets -- -D warnings
       - name: Run cargo fmt check
@@ -46,14 +43,13 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
-          default: true
+          rustflags: -D warnings
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.8
       - name: cargo install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
@@ -66,16 +62,13 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
-          default: true
+          rustflags: -D warnings
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
-        with:
-          version: "v0.4.0"
+        uses: mozilla-actions/sccache-action@v0.0.8
       - name: Run cargo test
         run: cargo test --all-features
 
@@ -85,17 +78,16 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
-          default: true
+          rustflags: -D warnings
           components: llvm-tools-preview
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.8
       - name: cargo install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: cargo generate-lockfile
@@ -105,6 +97,6 @@ jobs:
         run: cargo llvm-cov --locked --all-features --lcov --output-path lcov.info
       - name: Upload to codecov.io
         if: ${{ github.repository == 'Sovereign-Labs/nmt-rs' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false

--- a/src/simple_merkle/tree.rs
+++ b/src/simple_merkle/tree.rs
@@ -502,11 +502,11 @@ where
             params: &SubrootParams<M>,
         ) -> Result<M::Output, RangeProofError> {
             if range.len() == 1 {
-                return params
+                params
                     .extra_leaves
                     .get(range.start - params.leaves_start_idx)
                     .ok_or(RangeProofError::MissingLeaf)
-                    .cloned();
+                    .cloned()
             } else {
                 let split_point = next_smaller_po2(range.len()) + range.start;
                 let left = local_subroot_from_leaves(range.start..split_point, params)?;


### PR DESCRIPTION
Github [dropped support for the old way of providing cache](https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/) earlier this year, this updates actions used in CI to new versions. Rust toolchain action was switched to https://github.com/actions-rust-lang/setup-rust-toolchain